### PR TITLE
added travis continues integration config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+python:
+  - "3.2"
+  - "3.3"
+before_install:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+install:
+  - "pip install --upgrade http://pyglet.googlecode.com/archive/tip.zip"
+script: 
+  - "python -m tests.runtests"
+notifications:
+  email:
+    on_success: change
+    on_failure: change


### PR DESCRIPTION
Travis is a continues integration service that will run unittest every time someone commits or makes a pull request towards a git repo. The service is free for open source projects and i think its a good service and it will make sure that the code at github always passes the unittest. A example from my fork of pyglet-gui:https://travis-ci.org/Norberg/pyglet-gui

Follow the instructions on https://travis-ci.org on how to create a account to run it on your repo.
