### PR TITLE
Support for formated text in Buttons

### DIFF
--- a/docs/button.rst
+++ b/docs/button.rst
@@ -15,7 +15,7 @@ because it is a controllable viewer with two states ("is pressed" and "is not pr
     A :class:`~pyglet_gui.controller.TwoStateController` and :class:`~pyglet_gui.core.Viewer`
     represented as a label and texture drawn on top of each other.
 
-    :param label: The string written in the button.
+    :param label: A string or a pyglet.text.Document written to the button.
     :param is_pressed: True if the button starts pressed
     :param on_press: A callback function of one argument called when the button is pressed  (optional).
 
@@ -23,7 +23,7 @@ because it is a controllable viewer with two states ("is pressed" and "is not pr
 
     .. attribute:: label
 
-        The label of the button (a string).
+        The label of the button, either a string or a pyglet.text.Document
 
     Accepted events:
 
@@ -39,7 +39,7 @@ because it is a controllable viewer with two states ("is pressed" and "is not pr
 
     A :class:`Button` that changes back to its original state when the mouse is released.
 
-    :param label: The string written in the button.
+    :param label: A string or a pyglet.text.Document written to the button.
     :param on_release: A callback function of one argument called when the button is released (optional).
 
     Accepted events:
@@ -56,7 +56,7 @@ because it is a controllable viewer with two states ("is pressed" and "is not pr
 
      A button drawn as a checkbox icon with the label on the side.
 
-    :param label: A string written in the button graphics.
+    :param label: A string or a pyglet.text.Document written to the button.
     :param is_pressed: True if the button starts pressed
     :param on_press: A callback function of one argument called when the button is pressed  (optional).
     :param align: Whether the label is left or right of the checkbox.
@@ -70,7 +70,7 @@ because it is a controllable viewer with two states ("is pressed" and "is not pr
 
     A :class:`Button` that is focusable and thus can be selected with TAB.
 
-    :param label: The string written in the button.
+    :param label: A string or a pyglet.text.Document written to the button.
     :param is_pressed: True if the button starts pressed
     :param on_press: A callback function of one argument called when the button is pressed  (optional).
 

--- a/examples/buttons.py
+++ b/examples/buttons.py
@@ -1,5 +1,7 @@
 from setup import *
 
+import pyglet
+
 from pyglet_gui.manager import Manager
 from pyglet_gui.buttons import Button, OneTimeButton, Checkbox
 from pyglet_gui.containers import VerticalContainer
@@ -40,8 +42,11 @@ theme = Theme({"font": "Lucida Grande",
                }
               }, resources_path='../theme/')
 
+htmlLabel = pyglet.text.decode_html("HTML Button - <b>Bold</b> <i>Italics</i>")
+
 # Set up a Manager
-Manager(VerticalContainer([Button(label="Persistent button"),
+Manager(VerticalContainer([Button(label="Persistent Button"),
+                           Button(label=htmlLabel),
                            OneTimeButton(label="One time button"),
                            Checkbox(label="Checkbox")]),
         window=window,

--- a/pyglet_gui/override.py
+++ b/pyglet_gui/override.py
@@ -9,7 +9,6 @@ class Label(pyglet.text.Label):
     def unload(self):
         self.delete()
 
-
 class InputLabel(pyglet.text.Label):
     def _get_left(self):
         if self._multiline:

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -60,6 +60,13 @@ class TestFocusButton(TestPygletGUI, GenericButtonTest):
         self.button.on_key_press(pyglet.window.key.ENTER,None)
         self.assertEqual(self.button.is_pressed, True)
 
+class TestHTMLFormatedButton(TestPygletGUI, GenericButtonTest):
+    def setUp(self):
+        TestPygletGUI.setUp(self)
+        htmlLabel = pyglet.text.decode_html("HTML Button - <b>Bold</b> <i>Italics</i>")
+        self.button = Button(label=htmlLabel)
+        GenericButtonTest.setUp(self)
+
 
 if __name__ == "__main__":
     import unittest


### PR DESCRIPTION
A button can now take a *Document as well as a plain text argument to
created the button label. This allow the user to create a formated
document as label. This follows the same pattern as document that
already supports formated input.
Ex.
html = pyglet.text.decode_html("HTML Button - <b>Bold</b> <i>Italics</i>")
button = Button(html)

This commits contains code, documentation, example code as well as test for
this feature.