### PR TITLE
added (type, obj) to super() calls, to enable python 2 support

### DIFF
--- a/pyglet_gui/text_input.py
+++ b/pyglet_gui/text_input.py
@@ -39,7 +39,10 @@ class TextInput(FocusMixin, Viewer):
         self._label = InputLabel(self._document.text,
                                  multiline=False,
                                  width=self.width-self._padding*2,
-                                 color=theme['text_color'], **self.get_batch('foreground'))
+                                 color=theme['text_color'],
+                                 font_name=theme['font'],
+                                 font_size=theme['font_size'],
+                                 **self.get_batch('foreground'))
 
     def _load_writing(self, theme):
         needed_width, needed_height = self._compute_needed_size()


### PR DESCRIPTION
I tried running the examples using python 2.7 and they all threw exceptions complaining about `super()` requiring more arguments. I did some research and apparently `super()` without args is python3 magic, but adding the arguments explicitly enables python2 support (probably >= 2.5, but I've only tested in 2.7)

Also, fixed `TextInput` theme font usage. The way it was, the _font_ and _font-size_ keys in the _input_ object in the theme dictionary would only apply to the edit state, but not the label state. I made it use the theme in both cases.
