### PR TITLE
Dusktreader/free mouse scroll from manager

### DIFF
--- a/examples/buttons.py
+++ b/examples/buttons.py
@@ -1,7 +1,7 @@
 from setup import *
 
 from pyglet_gui.manager import Manager
-from pyglet_gui.buttons import Button, OneTimeButton, Checkbox
+from pyglet_gui.buttons import Button, OneTimeButton, Checkbox, GroupButton
 from pyglet_gui.containers import VerticalContainer
 from pyglet_gui.theme import Theme
 
@@ -43,7 +43,13 @@ theme = Theme({"font": "Lucida Grande",
 # Set up a Manager
 Manager(VerticalContainer([Button(label="Persistent button"),
                            OneTimeButton(label="One time button"),
-                           Checkbox(label="Checkbox")]),
+                           Checkbox(label="Checkbox"),
+                           GroupButton(group_id='1', label="Group 1:Button 1"),
+                           GroupButton(group_id='1', label="Group 1:Button 2"),
+                           GroupButton(group_id='2', label="Group 2:Button 1"),
+                           GroupButton(group_id='2', label="Group 2:Button 2"),
+                           GroupButton(group_id='2', label="Group 2:Button 3"),
+                           ]),
         window=window,
         batch=batch,
         theme=theme)

--- a/pyglet_gui/buttons.py
+++ b/pyglet_gui/buttons.py
@@ -7,7 +7,6 @@ from pyglet_gui.controllers import TwoStateController
 from pyglet_gui.core import Viewer
 from pyglet_gui.mixins import FocusMixin
 
-
 class Button(TwoStateController, Viewer):
     def __init__(self, label="", is_pressed=False, on_press=None):
         TwoStateController.__init__(self, is_pressed=is_pressed, on_press=on_press)
@@ -75,6 +74,21 @@ class Button(TwoStateController, Viewer):
     def delete(self):
         TwoStateController.delete(self)
         Viewer.delete(self)
+
+
+class GroupButton(Button):
+    button_groups = {}
+
+    def __init__(self, group_id="", label="", is_pressed=False, on_press=None):
+        Button.__init__(self, label=label, is_pressed=is_pressed, on_press=on_press)
+        self.button_groups.setdefault(group_id, []).append(self)
+        self.group_id = group_id
+
+    def change_state(self):
+        for button in self.button_groups[self.group_id]:
+            if button._is_pressed and button is not self:
+                button.change_state()
+        super(GroupButton, self).change_state()
 
 
 class OneTimeButton(Button):

--- a/pyglet_gui/manager.py
+++ b/pyglet_gui/manager.py
@@ -299,7 +299,7 @@ class ControllerManager:
         elif self.wheel_hint in self._controllers:
             return self.wheel_hint.on_mouse_scroll(x, y, scroll_x, scroll_y)
         else:
-            return True
+            return False
 
     def on_text(self, text):
         if self._focus and text != '\r' and hasattr(self._focus, 'on_text'):


### PR DESCRIPTION
Only the latest commit should be considered as there is a different pull request for the group button commit.

This commit allows a mouse scroll event to pass over the ControllerMaster if there are no bound mouse scroll handlers. This was necessary for allowing other parts of my application to process the mouse wheel events even when the pyglet-gui components were active